### PR TITLE
remove sub_dann example

### DIFF
--- a/R/nearest_neighbor_adaptive.R
+++ b/R/nearest_neighbor_adaptive.R
@@ -36,13 +36,6 @@
 #' model |>
 #'   predict(new_data = two_class_dat)
 #'
-#' model <- nearest_neighbor_adaptive(neighbors = 2) |>
-#'   set_engine("sub_dann") |>
-#'   fit(formula = Class ~ A + B, data = two_class_dat)
-#'
-#' model |>
-#'   predict(new_data = two_class_dat)
-#'
 #' @export
 nearest_neighbor_adaptive <- function(mode = "classification", neighbors = NULL,
                                       neighborhood = NULL,

--- a/man/nearest_neighbor_adaptive.Rd
+++ b/man/nearest_neighbor_adaptive.Rd
@@ -64,11 +64,4 @@ model <- nearest_neighbor_adaptive(neighbors = 2) |>
 model |>
   predict(new_data = two_class_dat)
 
-model <- nearest_neighbor_adaptive(neighbors = 2) |>
-  set_engine("sub_dann") |>
-  fit(formula = Class ~ A + B, data = two_class_dat)
-
-model |>
-  predict(new_data = two_class_dat)
-
 }


### PR DESCRIPTION
This PR removes the sub_dann example so CRAN's check passes. Prior to changes, checks failed b/c example takes more than 5 seconds to run.